### PR TITLE
ascending by default, getAll supports offset and descending

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ query(
 
 #### Pagination
 
-If you use `toCallback`, it gives you all results in one go. If you want to get results in batches, you should use **`toPullStream`**, **`paginate`**, and optionally `startFrom` and `ascending`.
+If you use `toCallback`, it gives you all results in one go. If you want to get results in batches, you should use **`toPullStream`**, **`paginate`**, and optionally `startFrom` and `descending`.
 
 - **toPullStream** creates a [pull-stream] source to stream the results
 - **paginate** configures the size of each page stream to the pull-stream source
 - **startFrom** configures the beginning offset from where to start streaming
-- **ascending** configures the pagination stream to order results from oldest to newest
+- **descending** configures the pagination stream to order results from newest to oldest (otherwise the default order is oldest to newest)
 
 Example, **stream all messages of type `contact` from Alice or Bob in pages of size 10:**
 
@@ -138,7 +138,7 @@ pull(
 )
 ```
 
-**Stream all messages of type `contact` from Alice or Bob in pages of size 10, starting from the 15th message, sorted from oldest to newest:**
+**Stream all messages of type `contact` from Alice or Bob in pages of size 10, starting from the 15th message, sorted from newest to oldest:**
 
 ```js
 const pull = require('pull-stream')
@@ -149,7 +149,7 @@ const source = query(
   and(or(author(aliceId), author(bobId))),
   paginate(10),
   startFrom(15),
-  ascending(),
+  descending(),
   toPullStream()
 )
 
@@ -186,7 +186,6 @@ const results = query(
   and(or(author(aliceId), author(bobId))),
   paginate(10),
   startFrom(15),
-  ascending(),
   toAsyncIter()
 )
 
@@ -211,7 +210,7 @@ const {
   channel,
   paginate,
   startFrom,
-  ascending,
+  descending,
   debug,
   isRoot,
   isPrivate,
@@ -224,7 +223,7 @@ const {
 
 ## Low-level API
 
-### paginate(operation, offset, limit, reverse, cb)
+### paginate(operation, offset, limit, descending, cb)
 
 Query the database returning paginated results. If one or more indexes
 doesn't exist or are outdated, the indexes will be updated before the
@@ -280,10 +279,10 @@ some after processing that you wouldn't create and index for, but the
 overhead of decoding the buffers is small enough that I don't think it
 makes sense.
 
-### all(operation, cb)
+### all(operation, offset, descending, cb)
 
 Just like paginate except this will return all results given the
-operation.
+operation, and there is no `limit` argument.
 
 ### querySeq(operation, seq, cb)
 

--- a/README.md
+++ b/README.md
@@ -258,8 +258,11 @@ const {
 
 Query the database returning paginated results. If one or more indexes
 doesn't exist or are outdated, the indexes will be updated before the
-query is run. The results are sorted based on timestamp with latest
-first.
+query is run. The result is an object with the fields: 
+
+ - `data`: the actual messages
+ - `total`: the total number of messages
+ - `duration`: the number of ms the query took
 
 Operation can be of the following types:
 
@@ -312,8 +315,8 @@ makes sense.
 
 ### all(operation, offset, descending, cb)
 
-Just like paginate except this will return all results given the
-operation, and there is no `limit` argument.
+Similar to paginate except there is no `limit` argument and the result
+will be the messages directly.
 
 ### querySeq(operation, seq, cb)
 

--- a/example.js
+++ b/example.js
@@ -1,7 +1,7 @@
 const FlumeLog = require('async-flumelog')
 const pull = require('pull-stream')
 const JITDB = require('./index')
-const {query, fromDB, and, or, type, debug, author, paginate, toCallback, toPromise, toPullStream, toAsyncIter} = require("./operators")
+const {query, fromDB, and, or, type, debug, author, startFrom, paginate, toCallback, toPromise, toPullStream, toAsyncIter} = require("./operators")
 
 var raf = FlumeLog(process.argv[2], {blockSize: 64*1024})
 

--- a/example.js
+++ b/example.js
@@ -14,8 +14,6 @@ db.onReady(async () => {
   const mixy = '@G98XybiXD/amO9S/UyBKnWTWZnSKYS3YVB/5osSRHvY=.ed25519'
   const arj = '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519'
 
-  // FIXME: add offset to all
-
   if (true) query(
     fromDB(db),
     // debug(),

--- a/test/add.js
+++ b/test/add.js
@@ -32,15 +32,15 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
     addMsg(state.queue[1].value, raf, (err, msg2) => {
-      db.paginate(typeQuery, 0, 10, (err, results) => {
+      db.paginate(typeQuery, 0, 10, false, (err, results) => {
         t.equal(results.data.length, 2)
 
         // rerun on created index
-        db.paginate(typeQuery, 0, 10, (err, results) => {
+        db.paginate(typeQuery, 0, 10, true, (err, results) => {
           t.equal(results.data.length, 2)
           t.equal(results.data[0].value.author, keys2.id)
 
-          db.paginate(typeQuery, 0, 10, true, (err, results) => {
+          db.paginate(typeQuery, 0, 10, false, (err, results) => {
             t.equal(results.data.length, 2)
             t.equal(results.data[0].value.author, keys.id)
 
@@ -52,19 +52,19 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                 indexType: "author"
               }
             }
-            db.paginate(authorQuery, 0, 10, (err, results) => {
+            db.paginate(authorQuery, 0, 10, false, (err, results) => {
               t.equal(results.data.length, 1)
               t.equal(results.data[0].id, msg1.id)
 
               // rerun on created index
-              db.paginate(authorQuery, 0, 10, (err, results) => {
+              db.paginate(authorQuery, 0, 10, false, (err, results) => {
                 t.equal(results.data.length, 1)
                 t.equal(results.data[0].id, msg1.id)
 
                 db.paginate({
                   type: 'AND',
                   data: [authorQuery, typeQuery]
-                }, 0, 10, (err, results) => {
+                }, 0, 10, false, (err, results) => {
                   t.equal(results.data.length, 1)
                   t.equal(results.data[0].id, msg1.id)
 
@@ -83,7 +83,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                       type: 'OR',
                       data: [authorQuery, authorQuery2]
                     }]
-                  }, 0, 10, (err, results) => {
+                  }, 0, 10, false, (err, results) => {
                     t.equal(results.data.length, 2)
                     t.end()
                   })
@@ -113,11 +113,11 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
-    db.all(typeQuery, (err, results) => {
+    db.all(typeQuery, 0, false, (err, results) => {
       t.equal(results.length, 1)
 
       addMsg(state.queue[1].value, raf, (err, msg1) => {
-        db.all(typeQuery, (err, results) => {
+        db.all(typeQuery, 0, false, (err, results) => {
           t.equal(results.length, 2)
           t.end()
         })
@@ -151,7 +151,7 @@ prepareAndRunTest('grow', dir, (t, db, raf) => {
     }),
     push.collect((err, results) => {
       console.log("done inserting", results.length)
-      db.paginate(typeQuery, 0, 1, (err, results) => {
+      db.paginate(typeQuery, 0, 1, false, (err, results) => {
         t.equal(results.data.length, 1)
         t.equal(results.data[0].value.content.text, 'Testing 31999')
         t.end()
@@ -196,7 +196,7 @@ prepareAndRunTest('indexAll', dir, (t, db, raf) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
         addMsg(state.queue[3].value, raf, (err, msg) => {
-          db.all(authorQuery, (err, results) => {
+          db.all(authorQuery, 0, false, (err, results) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing 1')
             t.equal(Object.keys(db.indexes).length, 3+2+1+1)
@@ -233,16 +233,16 @@ prepareAndRunTest('indexAll multiple reindexes', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
-      db.all(typeQuery('post'), (err, results) => {
+      db.all(typeQuery('post'), 0, false, (err, results) => {
         t.equal(results.length, 1)
         t.equal(results[0].value.content.text, 'Testing 1')
 
         addMsg(state.queue[2].value, raf, (err, msg) => {
           addMsg(state.queue[3].value, raf, (err, msg) => {
-            db.all(typeQuery('about'), (err, results) => {
+            db.all(typeQuery('about'), 0, false, (err, results) => {
               t.equal(results.length, 1)
 
-              db.all(typeQuery('post'), (err, results) => {
+              db.all(typeQuery('post'), 0, false, (err, results) => {
                 t.equal(results.length, 2)
                 t.deepEqual(db.indexes['type_post'].data.array(), [0, 2])
                 t.deepEqual(db.indexes['type_contact'].data.array(), [1])

--- a/test/del.js
+++ b/test/del.js
@@ -31,13 +31,13 @@ prepareAndRunTest('Delete', dir, (t, db, raf) => {
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
-    addMsg(state.queue[1].value, raf, (err, msg2, seq) => {
+    addMsg(state.queue[1].value, raf, (err, msg2, seq2) => {
       addMsg(state.queue[2].value, raf, (err, msg3) => {
-        raf.del(seq, () => {
-          db.paginate(typeQuery, 0, 10, (err, results) => {
-            t.deepEqual(results.data, [msg3, msg1])
+        raf.del(seq2, () => {
+          db.paginate(typeQuery, 0, 10, false, (err, results) => {
+            t.deepEqual(results.data, [msg1, msg3])
 
-            db.all(typeQuery, (err, results) => {
+            db.all(typeQuery, 0, false, (err, results) => {
               t.deepEqual(results, [msg1, msg3])
               t.end()
             })

--- a/test/live.js
+++ b/test/live.js
@@ -65,7 +65,7 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
     // create index
-    db.all(typeQuery, (err, results) => {
+    db.all(typeQuery, 0, false, (err, results) => {
       t.equal(results.length, 1)
 
       db.liveQuerySingleIndex(typeQuery, (err, results) => {
@@ -73,7 +73,7 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
         t.equal(results[0].id, state.queue[1].value.id)
 
         // rerun on updated index
-        db.all(typeQuery, (err, results) => {
+        db.all(typeQuery, 0, false, (err, results) => {
           t.equal(results.length, 2)
           t.end()
         })

--- a/test/operators.js
+++ b/test/operators.js
@@ -308,7 +308,7 @@ prepareAndRunTest('operator lte', dir, (t, db, raf) => {
 //   const msg = {type: 'post', text: 'Testing!'};
 //   let state = validate.initial();
 //   state = validate.appendNew(state, null, alice, msg, Date.now());
-//   state = validate.appendNew(state, null, bob, msg, Date.now());
+//   state = validate.appendNew(state, null, bob, msg, Date.now()+1);
 
 //   addMsg(state.queue[0].value, raf, (e1, msg1) => {
 //     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -332,7 +332,7 @@ prepareAndRunTest('operators toCallback', dir, (t, db, raf) => {
   const msg = {type: 'post', text: 'Testing!'};
   let state = validate.initial();
   state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now());
+  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -357,7 +357,7 @@ prepareAndRunTest('operators toPromise', dir, (t, db, raf) => {
   const msg = {type: 'post', text: 'Testing!'};
   let state = validate.initial();
   state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now());
+  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -386,7 +386,7 @@ prepareAndRunTest('operators toPullStream', dir, (t, db, raf) => {
   const msg = {type: 'post', text: 'Testing!'};
   let state = validate.initial();
   state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now());
+  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -417,7 +417,7 @@ prepareAndRunTest('operators toAsyncIter', dir, (t, db, raf) => {
   const msg = {type: 'post', text: 'Testing!'};
   let state = validate.initial();
   state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now());
+  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, async (e2, msg2) => {
@@ -451,7 +451,7 @@ prepareAndRunTest('operators toCallback with startFrom', dir, (t, db, raf) => {
   const msg = {type: 'post', text: 'Testing!'};
   let state = validate.initial();
   state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now());
+  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -475,7 +475,7 @@ prepareAndRunTest('operators toCallback with descending', dir, (t, db, raf) => {
   const msg = {type: 'post', text: 'Testing!'};
   let state = validate.initial();
   state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now());
+  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {

--- a/test/operators.js
+++ b/test/operators.js
@@ -14,7 +14,7 @@ const {
   fromDB,
   paginate,
   startFrom,
-  ascending,
+  descending,
   toCallback,
   toPromise,
   toPullStream,
@@ -123,7 +123,7 @@ prepareAndRunTest('operators multi or', dir, (t, db, raf) => {
 });
 
 prepareAndRunTest(
-  'operators paginate startFrom ascending',
+  'operators paginate startFrom descending',
   dir,
   (t, db, raf) => {
     const queryTreePaginate = query(
@@ -138,10 +138,10 @@ prepareAndRunTest(
       startFrom(5),
     );
 
-    const queryTreeAscending = query(
+    const queryTreeDescending = query(
       fromDB(db),
       and(type('post')),
-      ascending(),
+      descending(),
     );
 
     const queryTreeAll = query(
@@ -149,16 +149,16 @@ prepareAndRunTest(
       and(type('post')),
       startFrom(5),
       paginate(10),
-      ascending(),
+      descending(),
     );
 
     t.equal(queryTreePaginate.meta.pageSize, 10);
     t.equal(queryTreeStartFrom.meta.offset, 5);
-    t.equal(queryTreeAscending.meta.reverse, true);
+    t.equal(queryTreeDescending.meta.descending, true);
 
     t.equal(queryTreeAll.meta.pageSize, 10);
     t.equal(queryTreeAll.meta.offset, 5);
-    t.equal(queryTreeAll.meta.reverse, true);
+    t.equal(queryTreeAll.meta.descending, true);
 
     t.end();
   },
@@ -256,7 +256,6 @@ prepareAndRunTest('operators toPullStream', dir, (t, db, raf) => {
           fromDB(db),
           or(author(alice.id), author(bob.id)),
           paginate(2),
-          ascending(),
           toPullStream(),
         ),
         pull.collect((err, pages) => {
@@ -289,7 +288,6 @@ prepareAndRunTest('operators toAsyncIter', dir, (t, db, raf) => {
           fromDB(db),
           or(author(alice.id), author(bob.id)),
           paginate(2),
-          ascending(),
           toAsyncIter(),
         )
         for await (let page of results) {
@@ -306,6 +304,56 @@ prepareAndRunTest('operators toAsyncIter', dir, (t, db, raf) => {
       } catch (err) {
         t.fail(err)
       }
+    });
+  });
+});
+
+prepareAndRunTest('operators toCallback with startFrom', dir, (t, db, raf) => {
+  const msg = {type: 'post', text: 'Testing!'};
+  let state = validate.initial();
+  state = validate.appendNew(state, null, alice, msg, Date.now());
+  state = validate.appendNew(state, null, bob, msg, Date.now());
+
+  addMsg(state.queue[0].value, raf, (e1, msg1) => {
+    addMsg(state.queue[1].value, raf, (e2, msg2) => {
+      query(
+        fromDB(db),
+        or(author(alice.id), author(bob.id)),
+        startFrom(1),
+        toCallback((err, msgs) => {
+          t.error(err, 'toCallback got no error');
+          t.equal(msgs.length, 1, 'toCallback got one messages');
+          t.equal(msgs[0].value.author, bob.id);
+          t.equal(msgs[0].value.content.type, 'post');
+          t.end();
+        }),
+      );
+    });
+  });
+});
+
+prepareAndRunTest('operators toCallback with descending', dir, (t, db, raf) => {
+  const msg = {type: 'post', text: 'Testing!'};
+  let state = validate.initial();
+  state = validate.appendNew(state, null, alice, msg, Date.now());
+  state = validate.appendNew(state, null, bob, msg, Date.now());
+
+  addMsg(state.queue[0].value, raf, (e1, msg1) => {
+    addMsg(state.queue[1].value, raf, (e2, msg2) => {
+      query(
+        fromDB(db),
+        or(author(alice.id), author(bob.id)),
+        descending(),
+        toCallback((err, msgs) => {
+          t.error(err, 'toCallback got no error');
+          t.equal(msgs.length, 2, 'toCallback got two messages');
+          t.equal(msgs[0].value.author, bob.id);
+          t.equal(msgs[0].value.content.type, 'post');
+          t.equal(msgs[1].value.author, alice.id);
+          t.equal(msgs[1].value.content.type, 'post');
+          t.end();
+        }),
+      );
     });
   });
 });

--- a/test/query-seq.js
+++ b/test/query-seq.js
@@ -29,7 +29,7 @@ prepareAndRunTest('Basic', dir, (t, db, raf) => {
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
-    db.all(typeQuery, (err, results) => {
+    db.all(typeQuery, 0, false, (err, results) => {
       t.equal(results.length, 1)
       t.equal(results[0].id, state.queue[0].value.id)
       const seq1 = db.getSeq(typeQuery)

--- a/test/query.js
+++ b/test/query.js
@@ -43,12 +43,12 @@ prepareAndRunTest('Multiple types', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(typeQuery, (err, results) => {
+        db.all(typeQuery, 0, false, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.type, 'post')
           t.equal(results[1].value.content.type, 'post')
 
-          db.all(contactQuery, (err, results) => {
+          db.all(contactQuery, 0, false, (err, results) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.type, 'contact')
 
@@ -82,7 +82,7 @@ prepareAndRunTest('Top 1 multiple types', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.paginate(typeQuery, 0, 1, (err, results) => {
+        db.paginate(typeQuery, 0, 1, true, (err, results) => {
           t.equal(results.data.length, 1)
           t.equal(results.data[0].value.content.text, 'Testing 2!')
           t.end()
@@ -114,7 +114,7 @@ prepareAndRunTest('Offset', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.paginate(typeQuery, 1, 1, (err, results) => {
+        db.paginate(typeQuery, 1, 1, true, (err, results) => {
           t.equal(results.data.length, 1)
           t.equal(results.data[0].value.content.text, 'Testing!')
           t.end()
@@ -140,7 +140,7 @@ prepareAndRunTest('Buffer', dir, (t, db, raf) => {
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
-    db.paginate(typeQuery, 0, 1, (err, results) => {
+    db.paginate(typeQuery, 0, 1, true, (err, results) => {
       t.equal(results.data.length, 1)
       t.equal(results.data[0].value.content.text, 'Testing!')
       t.end()
@@ -167,7 +167,7 @@ prepareAndRunTest('Undefined', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
-      db.paginate(typeQuery, 0, 1, (err, results) => {
+      db.paginate(typeQuery, 0, 1, true, (err, results) => {
         t.equal(results.data.length, 1)
         t.equal(results.data[0].value.content.text, 'Testing no root')
         t.end()
@@ -212,30 +212,30 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
     addMsg(state.queue[1].value, raf, (err, dbMsg2) => {
       addMsg(state.queue[2].value, raf, (err, dbMsg3) => {
         addMsg(state.queue[3].value, raf, (err, dbMsg4) => {
-          db.all(filterQuery, (err, results) => {
+          db.all(filterQuery, 0, false, (err, results) => {
             t.equal(results.length, 3)
             t.equal(results[0].value.content.text, '2')
 
             filterQuery.data[0].type = 'GTE'
-            db.all(filterQuery, (err, results) => {
+            db.all(filterQuery, 0, false, (err, results) => {
               t.equal(results.length, 4)
               t.equal(results[0].value.content.text, '1')
 
               filterQuery.data[0].type = 'LT'
               filterQuery.data[0].data.value = 3
-              db.all(filterQuery, (err, results) => {
+              db.all(filterQuery, 0, false, (err, results) => {
                 t.equal(results.length, 2)
                 t.equal(results[0].value.content.text, '1')
 
                 filterQuery.data[0].type = 'LTE'
-                db.all(filterQuery, (err, results) => {
+                db.all(filterQuery, 0, false, (err, results) => {
                   t.equal(results.length, 3)
                   t.equal(results[0].value.content.text, '1')
 
                   filterQuery.data[0].type = 'GT'
                   filterQuery.data[0].data.indexName = 'timestamp'
                   filterQuery.data[0].data.value = dbMsg1.value.timestamp
-                  db.all(filterQuery, (err, results) => {
+                  db.all(filterQuery, 0, false, (err, results) => {
                     t.equal(results.length, 3)
                     t.equal(results[0].value.content.text, '2')
 
@@ -281,7 +281,7 @@ prepareAndRunTest('Data seqs', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.paginate(dataQuery, 0, 1, (err, results) => {
+        db.paginate(dataQuery, 0, 1, true, (err, results) => {
           t.equal(results.data.length, 1)
           t.equal(results.data[0].value.content.text, 'Testing no root')
           t.end()
@@ -309,7 +309,7 @@ prepareAndRunTest('Data offsets simple', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(dataQuery, (err, results) => {
+        db.all(dataQuery, 0, false, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.name, 'Test')
           t.equal(results[1].value.content.text, 'Testing no root')
@@ -350,7 +350,7 @@ prepareAndRunTest('Data offsets', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.paginate(dataQuery, 0, 1, (err, results) => {
+        db.paginate(dataQuery, 0, 1, true, (err, results) => {
           t.equal(results.data.length, 1)
           t.equal(results.data[0].value.content.text, 'Testing no root')
           t.end()
@@ -404,7 +404,7 @@ prepareAndRunTest('Multiple ands', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(allQuery, (err, results) => {
+        db.all(allQuery, 0, false, (err, results) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing 2!')
           t.end()
@@ -473,7 +473,7 @@ prepareAndRunTest('Multiple ors', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(allQuery, (err, results) => {
+        db.all(allQuery, 0, false, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.text, 'Testing!')
           t.equal(results[1].value.content.text, 'Testing 2!')


### PR DESCRIPTION
- `getTop` and `getAll` both do ascending order by default
- `getAll` supports arguments `offset` and `descending`
- `getTop` and `getAll` implementations looked so similar, I made a common function called `getValuesFromBitsetSlice`
- Removed the optionality of the `reverse` argument
  - It must always be provided
  - Assuming we won't use `getTop`/`getAll` as a direct API, but instead we'll use higher level APIs, I wanted to reduce some of the magic and code size of the implementation
- Add test for `startFrom`+`toCallback`
- Add test for `descending`+`toCallback`